### PR TITLE
count($products) will throw error on php7.2

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -585,7 +585,7 @@ class Ganalytics extends Module
     {
         $resultProducts = [];
         if (!is_array($products)) {
-            return false;
+            return [];
         }
 
         $currency = new Currency($this->context->currency->id);


### PR DESCRIPTION
on PHP 7.2 count() argument should be array or object.
see line 565