### PR TITLE
Fix that the Product Quick View event was not sent

### DIFF
--- a/views/js/GoogleAnalyticActionLib.js
+++ b/views/js/GoogleAnalyticActionLib.js
@@ -116,7 +116,11 @@ var MBG = GoogleAnalyticEnhancedECommerce = {
     ga('send', 'event', 'Ecommerce', 'Refund', { 'nonInteraction': 1 });
   },
   addProductClick: function (Product) {
-    var ClickPoint = jQuery('a[href$="' + Product.url + '"].quick-view');
+    if(!Product.url) { return; }
+    var unsafeProductUrl = decodeURIComponent(Product.url);
+    var ClickPoint = jQuery('a[href].quick-view').filter(function () {
+        return jQuery(this).attr('href').indexOf(unsafeProductUrl) !== -1;
+    });
 
     ClickPoint.on("click", function () {
       GoogleAnalyticEnhancedECommerce.add(Product);


### PR DESCRIPTION
There is a different escaping of Product url in the theme (htmlspecialchars() actually). And the selector was `$=` instead of `^=`. Therefore, ClickPoint was empty.

I decided to keep urlencoding. And I found this way quite elegant and safe.